### PR TITLE
fix: button links now work on click

### DIFF
--- a/client/app/routes.ts
+++ b/client/app/routes.ts
@@ -1,4 +1,4 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig } from "@react-router/dev/routes";
 import { flatRoutes } from "@react-router/fs-routes"
 
 export default flatRoutes() satisfies RouteConfig;

--- a/client/app/routes/_app._index.tsx
+++ b/client/app/routes/_app._index.tsx
@@ -23,25 +23,29 @@ export default function Root() {
         </h2>
 
         <div className="flex flex-row gap-2 mt-6">
-          <Button
-            href="/listings"
-            variant="solid"
-            size="lg"
-            color="primary"
-            className="w-fit"
-            radius="sm"
-          >
-            <Link to="/listings">Browse</Link>
-          </Button>
-          <Button
-            variant="ghost"
-            size="lg"
-            color="primary"
-            className="w-fit"
-            radius="sm"
-          >
-            <Link to="/listings/new">Make a Listing</Link>
-          </Button>
+          <Link to="/listings">
+            <Button
+              variant="solid"
+              size="lg"
+              color="primary"
+              className="w-fit"
+              radius="sm"
+            >
+              Browse
+            </Button>
+          </Link>
+
+          <Link to="/listings/new">
+            <Button
+              variant="ghost"
+              size="lg"
+              color="primary"
+              className="w-fit"
+              radius="sm"
+            >
+              Make a Listing
+            </Button>
+          </Link>
         </div>
       </section>
     </main>


### PR DESCRIPTION
Buttons now work on click.

Before, the link was on the text, so if you clicked on the button but not where the text was it would not navigate.

Now the Link wraps the entire button so it will navigate on click no matter where you click on the button.
