### PR TITLE
Feat: Added Pagnation UI to the footer of listings page

### DIFF
--- a/client/app/components/navbar.tsx
+++ b/client/app/components/navbar.tsx
@@ -61,9 +61,13 @@ export default function AppNavbar({ user }: Props) {
           aria-label={isMenuOpen ? "Close menu" : "Open menu"}
           className="md:hidden"
         />
-        <NavbarBrand className="flex items-left text-xl text-blue-600 font-bold">
-          GatorMarket
-        </NavbarBrand>
+        <NavbarBrand className="flex items-left">
+        <Link href="/" className="cursor-pointer">
+          <span className="text-xl font-bold text-blue-600">
+            GatorMarket
+          </span>
+        </Link>
+      </NavbarBrand>
       </NavbarContent>
 
       <NavbarContent

--- a/client/app/routes/_app._protected.profile.tsx
+++ b/client/app/routes/_app._protected.profile.tsx
@@ -73,7 +73,7 @@ export default function Profile({}: Route.ComponentProps) {
 
   return (
     <main className="min-h-screen w-full">
-      <div className="max-w-4xl mx-auto pt-24 flex flex-col gap-4 px-6">
+      <div className="max-w-4xl mx-auto pt-16 flex flex-col gap-4 px-6">
         <Avatar
           name={hasName ? fullName : undefined}
           src={user.profile_picture_url || "/GatorAvatarTemporary.png"}
@@ -107,7 +107,7 @@ export default function Profile({}: Route.ComponentProps) {
         </div>
 
         {/* LISTINGS SECTION */}
-        <div className="mt-12 flex flex-col gap-3">
+        <div className="mt-12 flex flex-col gap-3 pb-6">
           <h2 className="text-2xl font-medium">My Listings</h2>
           <div className="w-full flex-row flex flex-wrap gap-3">
             {loading ? (

--- a/client/app/routes/_app.about.tsx
+++ b/client/app/routes/_app.about.tsx
@@ -41,7 +41,7 @@ export default function About() {
         isVisible ? "opacity-100" : "opacity-0"
       }`}
     >
-      <main className="flex flex-col items-center w-full mt-10 px-5 flex-grow">
+      <main className="flex flex-col items-center w-full mt-10 px-5 flex-grow mb-10">
         <Card
           className={`max-w-4xl w-full shadow-2xl shadow-blue-950/50 bg-gradient-to-tr from-zinc-50/80 to-zinc-200/80 
                      rounded-2xl p-8 backdrop-blur-md ${isVisible ? "animate-fadeup" : ""}`}

--- a/client/app/routes/_app.listings.tsx
+++ b/client/app/routes/_app.listings.tsx
@@ -1,12 +1,19 @@
 "use client";
 import { useEffect, useState } from "react";
-import { Card, CardHeader, CardBody, CardFooter } from "@heroui/react";
-import AppNavbar from "~/components/navbar";
-import { type Listing } from "~/components/listcard";
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  Spinner,
+  Select,
+  SelectItem,
+  Input,
+  Pagination,
+} from "@heroui/react";
 import { z } from "zod";
-import type { Route } from "./+types/_app.about";
+import { type Listing } from "~/components/listcard";
 import ListingCard from "~/components/ListingCard";
-import { Select, SelectItem, Input, Spinner } from "@heroui/react";
+import type { Route } from "./+types/_app.about";
 
 const sellerSchema = z.object({
   first_name: z.string(),
@@ -24,7 +31,7 @@ const sortOptions = [
 export const listingSchema = z.object({
   id: z.number(),
   title: z.string(),
-  description: z.string(),
+  description: z.string().optional(),
   price_cents: z.number(),
   status: z.enum(["active", "draft", "sold", "inactive", "archived"]),
   created_at: z.string(),
@@ -35,14 +42,6 @@ export const listingSchema = z.object({
 
 const listingsResponseSchema = z.array(listingSchema);
 
-const statusClasses: Record<Listing["status"], string> = {
-  active: "bg-green-200 text-green-800",
-  draft: "bg-gray-200 text-gray-800",
-  sold: "bg-red-200 text-red-800",
-  inactive: "bg-yellow-200 text-yellow-800",
-  archived: "bg-gray-400 text-white",
-};
-
 export default function ListingsPage({}: Route.ComponentProps) {
   const [listings, setListings] = useState<Listing[]>([]);
   const [sortOption, setSortOption] = useState<string>("");
@@ -50,32 +49,41 @@ export default function ListingsPage({}: Route.ComponentProps) {
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState<string>("");
 
-  // FETCH LISTINGS FUNCTION
-  const fetchListings = async (sortQuery?: string) => {
+  const [page, setPage] = useState<number>(1);
+  const cardsPerPage = 40; // WE CAN CHANGE THIS IF U WANT
+  const [totalPages, setTotalPages] = useState<number>(1);
+
+  const fetchListings = async (sortQuery?: string, pageNum: number = page) => {
     setLoading(true);
     setError(null);
     try {
       const apiURL = import.meta.env.VITE_API_URL;
-      let url = `${apiURL}/listings`;
+      let url = `${apiURL}/listings?page_num=${pageNum}&card_num=${cardsPerPage}`;
 
-      if (sortQuery && sortQuery.length > 0) {
+      if (sortQuery) {
         const [sort_by, orderPart] = sortQuery.split("&");
         const order = orderPart?.split("=")[1];
-        url += `?sort_by=${sort_by}&order=${order}`;
+        url += `&sort_by=${sort_by}&order=${order}`;
       }
 
       const res = await fetch(url);
       if (!res.ok) {
-        if (res.status === 400) {
-          const msg = await res.json();
-          throw new Error(msg.detail || "Invalid sort option. Please try again.");
-        }
-        throw new Error(`Error fetching listings: ${res.status}`);
+        const msg = await res.json();
+        throw new Error(msg.detail || `Error ${res.status}`);
       }
 
       const data = await res.json();
-      const parsedListings = listingsResponseSchema.parse(data);
-      setListings(parsedListings);
+
+      if (Array.isArray(data)) {
+        const parsedListings = listingsResponseSchema.parse(data);
+        setListings(parsedListings);
+
+        // PLACEHOLDER
+        setTotalPages(5);
+      } else {
+        setListings([]);
+        setTotalPages(1);
+      }
     } catch (err: any) {
       console.error("Failed to fetch listings:", err);
       setError(err.message || "Failed to load listings.");
@@ -85,15 +93,8 @@ export default function ListingsPage({}: Route.ComponentProps) {
   };
 
   useEffect(() => {
-    fetchListings();
-  }, []);
-
-  // REFETCH WHEN SORTOPTION CHANGES
-  useEffect(() => {
-    if (sortOption !== undefined) {
-      fetchListings(sortOption);
-    }
-  }, [sortOption]);
+    fetchListings(sortOption, page);
+  }, [sortOption, page]);
 
   const filteredListings = listings.filter((listing) =>
     listing.title.toLowerCase().includes(searchTerm.toLowerCase())
@@ -101,12 +102,12 @@ export default function ListingsPage({}: Route.ComponentProps) {
 
   return (
     <main className="max-w-7xl mx-auto pt-[1rem] xl:px-0 px-4 pb-10">
-      <h1 className="text-2xl font-semibold">Browse Listings</h1>
+      <h1 className="text-2xl font-semibold mb-4">Browse Listings</h1>
+
+      {/* SEARCH + SORT */}
       <div className="mt-2 flex gap-4 items-center">
-        {/* SEARCH BAR */}
         <div className="w-full md:w-4xl">
           <Input
-            label=""
             size="lg"
             placeholder="Search listings..."
             value={searchTerm}
@@ -114,30 +115,39 @@ export default function ListingsPage({}: Route.ComponentProps) {
           />
         </div>
 
-        {/* SORT DROPDOWN */}
         <div className="md:w-46 w-full">
           <Select
             label="Sort by"
             size="sm"
             className="py-1"
-            placeholder=""
             selectedKeys={sortOption ? [sortOption] : []}
             onSelectionChange={(keys) => {
               const selected = Array.from(keys)[0] as string;
               setSortOption(selected || "");
+              setPage(1); // RESETS ON SORT CHANGE
             }}
             items={sortOptions}
           >
             {(item) => <SelectItem key={item.query}>{item.label}</SelectItem>}
           </Select>
         </div>
+
+        {/* RIGHT FILTER ITS SUPPOSED TO BE FIXED BUT IT MOVES ON SCROLL HELP MEEEEEE*/}
+        <aside className="hidden sm:block fixed top-20 right-4 w-[220px] h-[calc(100vh-5rem)] overflow-y-auto z-50">
+          <Card className="p-3 shadow-sm border border-gray-200">
+            <CardHeader className="text-sm font-semibold pb-1 border-b border-neutral-200">
+              Filters (Coming Soon)
+            </CardHeader>
+            <CardBody className="pt-3 space-y-2 text-sm text-default-600">
+              <p>hewwo hewwo hewwo hewwo hewwo hewwo hewwo hewwo hewwo hewwo</p>
+            </CardBody>
+          </Card>
+        </aside>
       </div>
 
       {/* ERROR */}
       {error && (
-        <div className="mt-6 text-red-600 bg-red-100 p-3 rounded-md">
-          {error}
-        </div>
+        <div className="mt-6 text-red-600 bg-red-100 p-3 rounded-md">{error}</div>
       )}
 
       {/* LOADING */}
@@ -147,21 +157,26 @@ export default function ListingsPage({}: Route.ComponentProps) {
         </div>
       )}
 
-      {/* LISTINGS*/}
+      {/* LISTINGS GRID */}
       {!loading && !error && (
-        <div
-          className="
-            mt-8
-            grid
-            gap-6
-            grid-cols-[repeat(auto-fill,minmax(200px,max-content))]
-          "
-        >
+        <div className="mt-8 grid gap-6 grid-cols-[repeat(auto-fill,minmax(200px,max-content))]">
           {filteredListings.map((listing) => (
             <ListingCard key={listing.id} {...listing} />
           ))}
         </div>
       )}
+
+      {/* PAGINATION UI */}
+      <footer className="mt-8 flex justify-start">
+        <Pagination
+          page={page}
+          total={totalPages}
+          size="lg"
+          variant="light"
+          showControls={true}
+          onChange={(newPage) => setPage(newPage)}
+        />
+      </footer>
     </main>
   );
 }


### PR DESCRIPTION
Fixes #60 Hello chat, so I added pagnation controls but we have a few problems. The listings endpoint just returns the listings on the current page and i lowk need the total number of listings returned from the backend so i can use it to calculate how many pages we need. I have a placeholder of 5 pages rn and set the number of cards to a beautiful even 40 cards per page. Alsoooo can we create a search endpoint so we can search the whole database bc rn I just have it only searching the current page. Pretty please.